### PR TITLE
{word2vec} Split up TrainModelThread function

### DIFF
--- a/src/word2vec.c
+++ b/src/word2vec.c
@@ -673,14 +673,368 @@ static void InitNet( void )
     CreateBinaryTree();
 }
 
+// train the cbow architecture
+static void TrainModelCBOW( long long b,
+                            long long word,
+                            long long sentence_position,
+                            long long sentence_length,
+                            const long long sen[MAX_SENTENCE_LENGTH + 1],
+                            unsigned long long *next_random,
+                            real *neu1,
+                            real *neu1e )
+{
+    long long cw = 0;
+    long long a = 0;
+    long long c = 0;
+    long long d = 0;
+    long long l2 = 0;
+    long long last_word = 0;
+    real f = 0;
+    real g = 0;
+
+    // in -> hidden
+    for ( a = b; a < window * 2 + 1 - b; a++ )
+    {
+        if ( a == window )
+        {
+            continue;
+        }
+
+        c = sentence_position - window + a;
+
+        if ( ( c < 0 ) || ( c >= sentence_length ) )
+        {
+            continue;
+        }
+
+        last_word = sen[c];
+
+        if ( last_word == -1 )
+        {
+            continue;
+        }
+
+        for ( c = 0; c < layer1_size; c++ )
+        {
+            neu1[c] += syn0[c + last_word * layer1_size];
+        }
+
+        cw++;
+    }
+
+    if ( cw == 0 )
+    {
+        return;
+    }
+
+    for ( c = 0; c < layer1_size; c++ )
+    {
+        neu1[c] /= cw;
+    }
+
+    if ( hs )
+    {
+        for ( d = 0; d < vocab[word].codelen; d++ )
+        {
+            f = 0;
+            l2 = vocab[word].point[d] * layer1_size;
+
+            // Propagate hidden -> output
+            for ( c = 0; c < layer1_size; c++ )
+            {
+                f += neu1[c] * syn1[c + l2];
+            }
+
+            if ( ( f <= -MAX_EXP ) || ( f >= MAX_EXP ) )
+            {
+                continue;
+            }
+            else
+            {
+                f = expTable[(int)( ( f + MAX_EXP ) * ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )];
+            }
+
+            // 'g' is the gradient multiplied by the learning rate
+            g = ( 1 - vocab[word].code[d] - f ) * alpha;
+
+            // Propagate errors output -> hidden
+            for ( c = 0; c < layer1_size; c++ )
+            {
+                neu1e[c] += g * syn1[c + l2];
+            }
+
+            // Learn weights hidden -> output
+            for ( c = 0; c < layer1_size; c++ )
+            {
+                syn1[c + l2] += g * neu1[c];
+            }
+        }
+    }
+
+    // NEGATIVE SAMPLING
+    if ( negative > 0 )
+    {
+        long long target = 0;
+        long long label = 0;
+
+        for ( d = 0; d < negative + 1; d++ )
+        {
+            if ( d == 0 )
+            {
+                target = word;
+                label = 1;
+            }
+            else
+            {
+                *next_random = *next_random * (unsigned long long)25214903917 + 11;
+                target = table[( *next_random >> 16 ) % table_size];
+
+                if ( target == 0 )
+                {
+                    target = *next_random % ( vocab_size - 1 ) + 1;
+                }
+                if ( target == word )
+                {
+                    continue;
+                }
+
+                label = 0;
+            }
+
+            l2 = target * layer1_size;
+            f = 0;
+
+            for ( c = 0; c < layer1_size; c++ )
+            {
+                f += neu1[c] * syn1neg[c + l2];
+            }
+
+            if ( f > MAX_EXP )
+            {
+                g = ( label - 1 ) * alpha;
+            }
+            else if ( f < -MAX_EXP )
+            {
+                g = ( label - 0 ) * alpha;
+            }
+            else
+            {
+                g = ( label -
+                      expTable[(int)( ( f + MAX_EXP ) * ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )] ) *
+                    alpha;
+            }
+
+            for ( c = 0; c < layer1_size; c++ )
+            {
+                neu1e[c] += g * syn1neg[c + l2];
+            }
+
+            for ( c = 0; c < layer1_size; c++ )
+            {
+                syn1neg[c + l2] += g * neu1[c];
+            }
+        }
+    }
+
+    // hidden -> in
+    for ( a = b; a < window * 2 + 1 - b; a++ )
+    {
+        if ( a != window )
+        {
+            continue;
+        }
+
+        c = sentence_position - window + a;
+
+        if ( ( c < 0 ) || ( c >= sentence_length ) )
+        {
+            continue;
+        }
+
+        last_word = sen[c];
+
+        if ( last_word == -1 )
+        {
+            continue;
+        }
+
+        for ( c = 0; c < layer1_size; c++ )
+        {
+            syn0[c + last_word * layer1_size] += neu1e[c];
+        }
+    }
+}
+
+// train skip-gram
+static void TrainModelSkipGram( long long b,
+                                long long word,
+                                long long sentence_position,
+                                long long sentence_length,
+                                const long long sen[MAX_SENTENCE_LENGTH + 1],
+                                unsigned long long *next_random,
+                                real *neu1e )
+{
+    long long a = 0;
+    long long c = 0;
+    long long d = 0;
+    long long l1 = 0;
+    long long l2 = 0;
+    long long target = 0;
+    long long label = 0;
+    long long last_word = 0;
+    real f = 0;
+    real g = 0;
+
+    for ( a = b; a < window * 2 + 1 - b; a++ )
+    {
+        if ( a == window )
+        {
+            continue;
+        }
+
+        c = sentence_position - window + a;
+
+        if ( ( c < 0 ) || ( c >= sentence_length ) )
+        {
+            continue;
+        }
+
+        last_word = sen[c];
+
+        if ( last_word == -1 )
+        {
+            continue;
+        }
+
+        l1 = last_word * layer1_size;
+
+        memset( neu1e, '\0', layer1_size * sizeof( real ) );
+
+        // HIERARCHICAL SOFTMAX
+        if ( hs )
+        {
+            for ( d = 0; d < vocab[word].codelen; d++ )
+            {
+                f = 0;
+                l2 = vocab[word].point[d] * layer1_size;
+
+                // Propagate hidden -> output
+                for ( c = 0; c < layer1_size; c++ )
+                {
+                    f += syn0[c + l1] * syn1[c + l2];
+                }
+
+                if ( ( f <= -MAX_EXP ) || ( f >= MAX_EXP ) )
+                {
+                    continue;
+                }
+                else
+                {
+                    f = expTable[(int)( ( f + MAX_EXP ) * ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )];
+                }
+
+                // 'g' is the gradient multiplied by the learning rate
+                g = ( 1 - vocab[word].code[d] - f ) * alpha;
+
+                // Propagate errors output -> hidden
+                for ( c = 0; c < layer1_size; c++ )
+                {
+                    neu1e[c] += g * syn1[c + l2];
+                }
+
+                // Learn weights hidden -> output
+                for ( c = 0; c < layer1_size; c++ )
+                {
+                    syn1[c + l2] += g * syn0[c + l1];
+                }
+            }
+        }
+        // NEGATIVE SAMPLING
+        if ( negative > 0 )
+        {
+            long long d = 0;
+
+            for ( d = 0; d < negative + 1; d++ )
+            {
+                if ( d == 0 )
+                {
+                    target = word;
+                    label = 1;
+                }
+                else
+                {
+                    *next_random = *next_random * (unsigned long long)25214903917 + 11;
+                    target = table[( *next_random >> 16 ) % table_size];
+
+                    if ( target == 0 )
+                    {
+                        target = *next_random % ( vocab_size - 1 ) + 1;
+                    }
+
+                    if ( target == word )
+                    {
+                        continue;
+                    }
+
+                    label = 0;
+                }
+
+                l2 = target * layer1_size;
+                f = 0;
+
+                for ( c = 0; c < layer1_size; c++ )
+                {
+                    f += syn0[c + l1] * syn1neg[c + l2];
+                }
+
+                if ( f > MAX_EXP )
+                {
+                    g = ( label - 1 ) * alpha;
+                }
+                else if ( f < -MAX_EXP )
+                {
+                    g = ( label - 0 ) * alpha;
+                }
+                else
+                {
+                    g = ( label -
+                          expTable[(int)( ( f + MAX_EXP ) * ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )] ) *
+                        alpha;
+                }
+
+                for ( c = 0; c < layer1_size; c++ )
+                {
+                    neu1e[c] += g * syn1neg[c + l2];
+                }
+
+                for ( c = 0; c < layer1_size; c++ )
+                {
+                    syn1neg[c + l2] += g * syn0[c + l1];
+                }
+            }
+        }
+
+        // Learn weights input -> hidden
+        for ( c = 0; c < layer1_size; c++ )
+        {
+            syn0[c + l1] += neu1e[c];
+        }
+    }
+}
+
 static void *TrainModelThread( void *id )
 {
-    long long a, b, d, cw, word, last_word, sentence_length = 0, sentence_position = 0;
-    long long word_count = 0, last_word_count = 0, sen[MAX_SENTENCE_LENGTH + 1];
-    long long l1, l2, c, target, label, local_iter = iter;
+    long long b = 0;
+    long long word = 0;
+    long long sentence_length = 0;
+    long long sentence_position = 0;
+    long long word_count = 0;
+    long long last_word_count = 0;
+    long long sen[MAX_SENTENCE_LENGTH + 1];
+
+    long long local_iter = iter;
     unsigned long long next_random = (long long)id;
     char eof = 0;
-    real f, g;
     clock_t now;
     real *neu1 = (real *)calloc( layer1_size, sizeof( real ) );
     real *neu1e = (real *)calloc( layer1_size, sizeof( real ) );
@@ -794,312 +1148,14 @@ static void *TrainModelThread( void *id )
         b = next_random % window;
 
         if ( cbow )
-        { // train the cbow architecture
-            // in -> hidden
-            cw = 0;
-
-            for ( a = b; a < window * 2 + 1 - b; a++ )
-            {
-                if ( a == window )
-                {
-                    continue;
-                }
-
-                c = sentence_position - window + a;
-
-                if ( ( c < 0 ) || ( c >= sentence_length ) )
-                {
-                    continue;
-                }
-
-                last_word = sen[c];
-
-                if ( last_word == -1 )
-                {
-                    continue;
-                }
-
-                for ( c = 0; c < layer1_size; c++ )
-                {
-                    neu1[c] += syn0[c + last_word * layer1_size];
-                }
-
-                cw++;
-            }
-
-            if ( cw )
-            {
-                for ( c = 0; c < layer1_size; c++ )
-                {
-                    neu1[c] /= cw;
-                }
-
-                if ( hs )
-                {
-                    for ( d = 0; d < vocab[word].codelen; d++ )
-                    {
-                        f = 0;
-                        l2 = vocab[word].point[d] * layer1_size;
-
-                        // Propagate hidden -> output
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            f += neu1[c] * syn1[c + l2];
-                        }
-
-                        if ( ( f <= -MAX_EXP ) || ( f >= MAX_EXP ) )
-                        {
-                            continue;
-                        }
-                        else
-                        {
-                            f = expTable[(int)( ( f + MAX_EXP ) *
-                                                ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )];
-                        }
-
-                        // 'g' is the gradient multiplied by the learning rate
-                        g = ( 1 - vocab[word].code[d] - f ) * alpha;
-
-                        // Propagate errors output -> hidden
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            neu1e[c] += g * syn1[c + l2];
-                        }
-
-                        // Learn weights hidden -> output
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            syn1[c + l2] += g * neu1[c];
-                        }
-                    }
-                }
-
-                // NEGATIVE SAMPLING
-                if ( negative > 0 )
-                {
-                    for ( d = 0; d < negative + 1; d++ )
-                    {
-                        if ( d == 0 )
-                        {
-                            target = word;
-                            label = 1;
-                        }
-                        else
-                        {
-                            next_random = next_random * (unsigned long long)25214903917 + 11;
-                            target = table[( next_random >> 16 ) % table_size];
-
-                            if ( target == 0 )
-                            {
-                                target = next_random % ( vocab_size - 1 ) + 1;
-                            }
-                            if ( target == word )
-                            {
-                                continue;
-                            }
-
-                            label = 0;
-                        }
-
-                        l2 = target * layer1_size;
-                        f = 0;
-
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            f += neu1[c] * syn1neg[c + l2];
-                        }
-
-                        if ( f > MAX_EXP )
-                        {
-                            g = ( label - 1 ) * alpha;
-                        }
-                        else if ( f < -MAX_EXP )
-                        {
-                            g = ( label - 0 ) * alpha;
-                        }
-                        else
-                        {
-                            g = ( label - expTable[(int)( ( f + MAX_EXP ) *
-                                                          ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )] ) *
-                                alpha;
-                        }
-
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            neu1e[c] += g * syn1neg[c + l2];
-                        }
-
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            syn1neg[c + l2] += g * neu1[c];
-                        }
-                    }
-                }
-                // hidden -> in
-                for ( a = b; a < window * 2 + 1 - b; a++ )
-                {
-                    if ( a != window )
-                    {
-                        continue;
-                    }
-
-                    c = sentence_position - window + a;
-
-                    if ( ( c < 0 ) || ( c >= sentence_length ) )
-                    {
-                        continue;
-                    }
-
-                    last_word = sen[c];
-
-                    if ( last_word == -1 )
-                    {
-                        continue;
-                    }
-
-                    for ( c = 0; c < layer1_size; c++ )
-                    {
-                        syn0[c + last_word * layer1_size] += neu1e[c];
-                    }
-                }
-            }
+        {
+            TrainModelCBOW( b, word, sentence_position, sentence_length, sen, &next_random, neu1,
+                            neu1e );
         }
         else
-        { // train skip-gram
-            for ( a = b; a < window * 2 + 1 - b; a++ )
-            {
-                if ( a == window )
-                {
-                    continue;
-                }
-
-                c = sentence_position - window + a;
-
-                if ( ( c < 0 ) || ( c >= sentence_length ) )
-                {
-                    continue;
-                }
-
-                last_word = sen[c];
-
-                if ( last_word == -1 )
-                {
-                    continue;
-                }
-
-                l1 = last_word * layer1_size;
-
-                memset( neu1e, '\0', layer1_size * sizeof( real ) );
-
-                // HIERARCHICAL SOFTMAX
-                if ( hs )
-                {
-                    for ( d = 0; d < vocab[word].codelen; d++ )
-                    {
-                        f = 0;
-                        l2 = vocab[word].point[d] * layer1_size;
-
-                        // Propagate hidden -> output
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            f += syn0[c + l1] * syn1[c + l2];
-                        }
-
-                        if ( ( f <= -MAX_EXP ) || ( f >= MAX_EXP ) )
-                        {
-                            continue;
-                        }
-                        else
-                        {
-                            f = expTable[(int)( ( f + MAX_EXP ) *
-                                                ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )];
-                        }
-
-                        // 'g' is the gradient multiplied by the learning rate
-                        g = ( 1 - vocab[word].code[d] - f ) * alpha;
-
-                        // Propagate errors output -> hidden
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            neu1e[c] += g * syn1[c + l2];
-                        }
-
-                        // Learn weights hidden -> output
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            syn1[c + l2] += g * syn0[c + l1];
-                        }
-                    }
-                }
-                // NEGATIVE SAMPLING
-                if ( negative > 0 )
-                {
-                    for ( d = 0; d < negative + 1; d++ )
-                    {
-                        if ( d == 0 )
-                        {
-                            target = word;
-                            label = 1;
-                        }
-                        else
-                        {
-                            next_random = next_random * (unsigned long long)25214903917 + 11;
-                            target = table[( next_random >> 16 ) % table_size];
-
-                            if ( target == 0 )
-                            {
-                                target = next_random % ( vocab_size - 1 ) + 1;
-                            }
-
-                            if ( target == word )
-                            {
-                                continue;
-                            }
-
-                            label = 0;
-                        }
-
-                        l2 = target * layer1_size;
-                        f = 0;
-
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            f += syn0[c + l1] * syn1neg[c + l2];
-                        }
-
-                        if ( f > MAX_EXP )
-                        {
-                            g = ( label - 1 ) * alpha;
-                        }
-                        else if ( f < -MAX_EXP )
-                        {
-                            g = ( label - 0 ) * alpha;
-                        }
-                        else
-                        {
-                            g = ( label - expTable[(int)( ( f + MAX_EXP ) *
-                                                          ( EXP_TABLE_SIZE / MAX_EXP / 2 ) )] ) *
-                                alpha;
-                        }
-
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            neu1e[c] += g * syn1neg[c + l2];
-                        }
-
-                        for ( c = 0; c < layer1_size; c++ )
-                        {
-                            syn1neg[c + l2] += g * syn0[c + l1];
-                        }
-                    }
-                }
-
-                // Learn weights input -> hidden
-                for ( c = 0; c < layer1_size; c++ )
-                {
-                    syn0[c + l1] += neu1e[c];
-                }
-            }
+        {
+            TrainModelSkipGram( b, word, sentence_position, sentence_length, sen, &next_random,
+                                neu1e );
         }
 
         sentence_position++;


### PR DESCRIPTION
Instead of jamming both CBOW and SkipGram into one massive `TrainModelThread` function, split them out for readability.